### PR TITLE
Fix xproperty target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ message(STATUS "xproperty v${${PROJECT_NAME}_VERSION}")
 # Dependencies
 # ============
 
-find_package(xtl 0.6.11 REQUIRED)
+set(xtl_REQUIRED_VERSION 0.6.11)
+find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
 message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
 
 # Build

--- a/xpropertyConfig.cmake.in
+++ b/xpropertyConfig.cmake.in
@@ -15,7 +15,12 @@
 
 @PACKAGE_INIT@
 
-set(PN xproperty)
-set_and_check(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set(${PN}_LIBRARY "")
-check_required_components(${PN})
+include(CMakeFindDependencyMacro)
+find_dependency(xtl @xtl_REQUIRED_VERSION@)
+
+if(NOT TARGET @PROJECT_NAME@)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+    get_target_property(@PROJECT_NAME@_INCLUDE_DIR @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
+endif()
+
+set(@PROJECT_NAME@_LIBRARY "")


### PR DESCRIPTION
Currently:
```cmake
target_link_libraries(xproperty_example PRIVATE xproperty)
```
doesn't work corrently.
Instead, we have to write it like this:
```cmake
target_include_directories(xproperty_example PRIVATE ${xproperty_INCLUDE_DIR})
```

This patch makes both ways work out.

References:
https://github.com/QuantStack/xtensor/commit/916ef251bcf081383a4710186d2f34f6f6987fff#diff-c447be55ed4ec941e194f99a40fcda93