### PR TITLE
Fix find_package xtl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@ message(STATUS "xproperty v${${PROJECT_NAME}_VERSION}")
 # ============
 
 set(xtl_REQUIRED_VERSION 0.7.0)
-find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
-message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
-
+if (NOT TARGET xtl)
+    find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+endif()
 # Build
 # =====
 


### PR DESCRIPTION
using find_package(xtl) twice   will cause error, when I use add_subdirectory to add it